### PR TITLE
Add -x option allowing files to be excluded from shared.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ An HTML file containing the complete dependencies and implementation for one or 
 - `-i`, `--shared_import string`       Name of the programatically created common dependency file. Defaults to 'shared.html'
 - `-s`, `--sharing_threshold number`   Number of endpoints an import must be found in to be added to 'shared_import'. For example, 2 will include all imports found in at least 2 endpoints, and 1 will include all dependencies of any endpoint. Defaults to 2.
 - `-d`, `--dest_dir string`            Destination for vulcanized application. Defaults to 'dist/'.
-- `-w`, `--workdir string`             Temporary directory for holding in-process files. DANGER: this directory will be deleted upon tool success. Defaults to 'tmp/'
+- `-w`, `--workdir string`             Temporary directory for holding in-process files. DANGER: this directory will be deleted upon process completion. Defaults to 'tmp/'
+- `-x`, `--exclude files string[]`     Files to be excluded from shared output. These excluded files has to be loaded manually.         

--- a/bin/wcs.js
+++ b/bin/wcs.js
@@ -120,8 +120,8 @@ var workPath = path.resolve(options.workdir);
 try {
   var workdir = fs.statSync(workPath);
   if (workdir) {
-    console.log("Working directory " + workPath + " already exists! Please clean up.");
-    process.exit(1);
+    rimraf.sync(workPath, {});
+    console.log("Delete working directory " + workPath + ".");
   }
 } catch (err) {
   // This is good. The workdir shouldn't exist.
@@ -141,4 +141,5 @@ shards.build().then(function(){
   rimraf.sync(workPath, {});
 }).catch(function(err){
   console.error(err.stack);
+  rimraf.sync(workPath, {});
 });

--- a/bin/wcs.js
+++ b/bin/wcs.js
@@ -117,6 +117,13 @@ if (options.help) {
 if (options.root !== '' && !/[\/\\]$/.test(options.root)) {
   options.root += '/';
 }
+if (options.dest_dir !== '' && !/[\/\\]$/.test(options.dest_dir)) {
+    options.dest_dir += '/';
+}
+if (options.workdir !== '' && !/[\/\\]$/.test(options.workdir)) {
+    options.workdir += '/';
+}
+
 var workdirPath = url.resolve(options.root, options.workdir);
 var workPath = path.resolve(workdirPath);
 try {

--- a/bin/wcs.js
+++ b/bin/wcs.js
@@ -83,7 +83,15 @@ var cli = cliArgs([
     defaultValue: "tmp/",
     description: "Temporary directory for holding in-process files. DANGER: " +
     " this directory will be deleted upon tool success. Defaults to 'tmp/'"
+  },
+  {
+    name: "shared_excludes",
+    type: String,
+    alias: "x",
+    multiple: true,
+    description: "Exclude files from shared output"
   }
+
 ]);
 
 var usage = cli.getUsage({

--- a/bin/wcs.js
+++ b/bin/wcs.js
@@ -14,6 +14,7 @@ var WebComponentShards = require('../wcs');
 var cliArgs = require("command-line-args");
 var fs = require('fs');
 var path = require('path');
+var url = require('url');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 
@@ -116,7 +117,8 @@ if (options.help) {
 if (options.root !== '' && !/[\/\\]$/.test(options.root)) {
   options.root += '/';
 }
-var workPath = path.resolve(options.workdir);
+var workdirPath = url.resolve(options.root, options.workdir);
+var workPath = path.resolve(workdirPath);
 try {
   var workdir = fs.statSync(workPath);
   if (workdir) {
@@ -126,6 +128,7 @@ try {
 } catch (err) {
   // This is good. The workdir shouldn't exist.
 }
+
 mkdirp.sync(workPath);
 
 var endpoints = options.endpoints;

--- a/wcs.js
+++ b/wcs.js
@@ -95,6 +95,7 @@ WebComponentShards.prototype = {
         output += '<link rel="import" href="' + baseUrl + '/' + commonDeps[dep] + '">\n';
       }
       var outDir = path.dirname(outputPath);
+
       mkdirp.sync(outDir);
       var fd = fs.openSync(outputPath, 'w');
       fs.writeSync(fd, output);

--- a/wcs.js
+++ b/wcs.js
@@ -154,7 +154,6 @@ WebComponentShards.prototype = {
       var sharedEndpointDone = new Promise(function(resolve, reject) {
         var vulcan = new Vulcan({
           fsResolver: this._getFSResolver(),
-          stripExcludes: this.shared_excludes,
           excludes: this.shared_excludes,
           inlineScripts: true,
           inlineCss: true,

--- a/wcs.js
+++ b/wcs.js
@@ -110,6 +110,7 @@ WebComponentShards.prototype = {
     }
     this.built = true;
     this._prepOutput();
+
     return this._synthesizeImport().then(function (commonDeps) {
       var endpointsVulcanized = [];
       // Vulcanize each endpoint

--- a/wcs.js
+++ b/wcs.js
@@ -112,17 +112,11 @@ WebComponentShards.prototype = {
     this._prepOutput();
     return this._synthesizeImport().then(function (commonDeps) {
       var endpointsVulcanized = [];
-
-      console.log('common deps to exclude from each view', commonDeps);
       // Vulcanize each endpoint
       this.endpoints.forEach(function(endpoint){
         var outPath = url.resolve(this.dest_dir, endpoint);
         var outDir = path.dirname(outPath);
         var pathToShared = path.relative(outDir, url.resolve(this.dest_dir, this.shared_import));
-
-        console.log('outdir', outDir);
-          console.log('dest_dir', this.dest_dir);
-          console.log('shared_import', this.shared_import);
         var oneEndpointDone = new Promise(function(resolve, reject) {
           var vulcan = new Vulcan({
             abspath: null,


### PR DESCRIPTION
1. Add -x option 
2. Fix bug that /tmp folder is created in the wrong place when root option is specified
3. Clean /tmp folder or working folder when process is completed. Without the fix, if the process end in error before the /tmp folder will exist and user has to delete manually before next run. 