### PR TITLE
exiting with a non-zero code when build fails

### DIFF
--- a/bin/wcs.js
+++ b/bin/wcs.js
@@ -133,4 +133,5 @@ shards.build().then(function(){
   rimraf.sync(workPath, {});
 }).catch(function(err){
   console.error(err.stack);
+  process.exit(-1);
 });


### PR DESCRIPTION
This fixes #16 by exiting with a non-zero value.
