### PR TITLE
Rethrow the error after logging

### DIFF
--- a/wcs.js
+++ b/wcs.js
@@ -52,6 +52,7 @@ WebComponentShards.prototype = {
     }).catch(function(err){
       console.log(err);
       console.log("FAILED IN GETDEPS");
+      throw err;
     });
   },
   _getCommonDeps: function _getCommonDeps() {


### PR DESCRIPTION
Eating the error here makes it impossible to actually fail a
build process due to missing dependencies, which then likely
produces wrong artifacts.

See also #17 
